### PR TITLE
Remove 'key' in URL so make the request valid on Google's API

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,15 +1,60 @@
 * Org-Gtasks
-Export all Google Tasks to org file.
+Export/import all Google Tasks to org files.
 
-This module has been HIGHLY inspired by [[https://github.com/myuhe/org-gcal.el][org-gcal]]
+This module has been HIGHLY inspired by [[https://github.com/myuhe/org-gcal.el][org-gcal]].
 
+`org-gtasks` will
+- sync all the task lists you have into org files, one per list
+- map `TODO` and `DONE` status to the same on Google Tasks
 
-** Config
+** Obtaining Google credentials
+
+1. Go to [[https://console.developers.google.com/project][Google Developers Console]]
+2. Create a project (with any name)
+3. Click on the project
+4. Click on *APIs & Services* then *Credentials*
+5. Click on *Create credentials* and select *OAuth Client ID*
+6. Select Application type /Other/ and give a name (e.g. /emacs/)
+6. Click on *Create*
+7. Copy the /Client ID/ and /Client secret/ into the relevant fields in the config (see below)
+8. Under the same *APIs & Services* menu section, select *Library*
+9. Search for *Tasks API*, click on it and click *Enable*
+
+You have now a project that accepts OAuth credentials and anables
+the /Tasks API/ for them.
+
+** Setup and config
 
 #+begin_src elisp
 (require 'org-gtasks)
 (org-gtasks-register-account :name "Perso"
-			     :directory "~/.emacs.d/gtasks/"
+                             :directory "~/.emacs.d/gtasks/"
                              :client-id "XXXX"
                              :client-secret "XXXX")
 #+end_src
+
+The first time you use `org-gtasks`, you need to authenticate.
+These are the steps you will go through:
+
+1. Make sure Emacs has read your config. Then, `M-x org-gtasks`
+   will show a prompt asking for the account. Enter its name,
+   e.g. /Perso/ as in the example config above.
+2. It will ask for the action, enter /Pull/. The actions are /Push/
+   and /Pull/ (defined in `org-gtasks-actions`).
+3. It will open your browser, and ask you to login. Then it will show
+   a code, that you need to ...
+4. ... paste into the minibuffer where it asks about it.
+
+You're done! You should now find one file per task list in the
+directory you have configured.
+
+** Usage
+
+Type `M-x org-gtasks`, enter the account name, the action
+(/Push/, /Pull/), and the operation takes a few seconds and you
+are done.
+
+** Limitations
+
+Currently, `org-gtasks` does not yet sync the dates, nor does it
+understand or map the hierachical structure of tasks.

--- a/README.org
+++ b/README.org
@@ -33,7 +33,7 @@ org files stored in a particular directory like so:
 8. Under the same *APIs & Services* menu section, select *Library*
 9. Search for *Tasks API*, click on it and click *Enable*
 
-You have now a project that accepts OAuth credentials and anables
+You have now a project that accepts OAuth credentials and enables
 the /Tasks API/ for them.
 
 ** Setup
@@ -51,6 +51,9 @@ These are the steps you will go through:
 
 You're done! You should now find one file per task list in the
 directory you have configured.
+
+*Note*: the OAuth token file is stored in the directory where the org
+files are written, named =.refresh-token=
 
 ** Usage
 

--- a/README.org
+++ b/README.org
@@ -3,9 +3,22 @@ Export/import all Google Tasks to org files.
 
 This module has been HIGHLY inspired by [[https://github.com/myuhe/org-gcal.el][org-gcal]].
 
-`org-gtasks` will
+=org-gtasks= will
 - sync all the task lists you have into org files, one per list
-- map `TODO` and `DONE` status to the same on Google Tasks
+- map =TODO= and =DONE= status to the same on Google Tasks
+
+** Config
+
+You can define an account, identified by its /name/ and with
+org files stored in a particular directory like so:
+
+#+begin_src elisp
+(require 'org-gtasks)
+(org-gtasks-register-account :name "Perso"
+                             :directory "~/.emacs.d/gtasks/"
+                             :client-id "XXXX"
+                             :client-secret "XXXX")
+#+end_src
 
 ** Obtaining Google credentials
 
@@ -23,24 +36,15 @@ This module has been HIGHLY inspired by [[https://github.com/myuhe/org-gcal.el][
 You have now a project that accepts OAuth credentials and anables
 the /Tasks API/ for them.
 
-** Setup and config
+** Setup
 
-#+begin_src elisp
-(require 'org-gtasks)
-(org-gtasks-register-account :name "Perso"
-                             :directory "~/.emacs.d/gtasks/"
-                             :client-id "XXXX"
-                             :client-secret "XXXX")
-#+end_src
-
-The first time you use `org-gtasks`, you need to authenticate.
+The first time you use ~org-gtasks~, you need to authenticate.
 These are the steps you will go through:
 
-1. Make sure Emacs has read your config. Then, `M-x org-gtasks`
+1. Make sure Emacs has read your config. Then, ~M-x org-gtasks~
    will show a prompt asking for the account. Enter its name,
    e.g. /Perso/ as in the example config above.
-2. It will ask for the action, enter /Pull/. The actions are /Push/
-   and /Pull/ (defined in `org-gtasks-actions`).
+2. It will ask for the action, enter /Pull/.
 3. It will open your browser, and ask you to login. Then it will show
    a code, that you need to ...
 4. ... paste into the minibuffer where it asks about it.
@@ -50,11 +54,12 @@ directory you have configured.
 
 ** Usage
 
-Type `M-x org-gtasks`, enter the account name, the action
-(/Push/, /Pull/), and the operation takes a few seconds and you
-are done.
+Type ~M-x org-gtasks~, enter the account name, an action,
+and the operation takes a few seconds and you are done.
+
+Possible actions are /Push/ and /Pull/ (defined in ~org-gtasks-actions~).
 
 ** Limitations
 
-Currently, `org-gtasks` does not yet sync the dates, nor does it
+Currently, ~org-gtasks~ does not yet sync the dates, nor does it
 understand or map the hierachical structure of tasks.

--- a/org-gtasks.el
+++ b/org-gtasks.el
@@ -317,11 +317,13 @@
       (org-gtasks-fetch-tasks account tasklist)
     (message "Cannot pull current tasklist")))
 
-(defun org-gtasks-pull (account)
+(defun org-gtasks-pull (account &optional listname)
   (let* ((tasklists (org-gtasks-tasklists account))
 	 (titles (mapcar 'tasklist-title tasklists))
 	 (collection (append (list "ALL") titles))
-	 (target (completing-read "Pull: " collection)))
+	 (target (if (eq listname nil)
+                     (completing-read "Pull: " collection)
+                   listname)))
     (if (string= target "ALL")
 	(org-gtasks-fetch-tasklists account)
       (when-let ((tasklist (org-gtasks-find-tasklist tasklists target)))
@@ -454,13 +456,15 @@
 						  account tasklist))
     (message "Cannot push current tasklist")))
 
-(defun org-gtasks-push (account)
+(defun org-gtasks-push (account &optional listname)
   (let* ((tasklists (org-gtasks-tasklists account))
 	 (collection (mapcar 'tasklist-title tasklists))
 	 (collection (if (> (length collection) 1)
                          (append (list "ALL") collection)
                        collection))
-	 (target (completing-read "Push: " collection)))
+	 (target (if (eq listname nil)
+                     (completing-read "Push: " collection)
+                   listname)))
     (if (string= target "ALL")
 	(org-gtasks-push-tasklists account tasklists
 				   (apply-partially #'org-gtasks-fetch-tasklists

--- a/org-gtasks.el
+++ b/org-gtasks.el
@@ -85,7 +85,7 @@
       (error "Ensure you enabled the Tasks API through the Developers Console"))
      ((and (> 299 status) (eq data nil))
       (message "Received HTTP: %s" (number-to-string status))
-      (error "Error occured, but no message body."))
+      (error "Error occurred, but no message body."))
      ((not (eq error-msg nil))
       (message "Status code: %s" (number-to-string status))
       (error "%s" (pp-to-string error-msg))))))

--- a/org-gtasks.el
+++ b/org-gtasks.el
@@ -161,7 +161,6 @@
 		    url
 		    :type "GET"
 		    :params `(("access_token" . ,(org-gtasks-access-token account))
-			      ("key" . ,(org-gtasks-client-secret account))
 			      ("singleEvents" . "True")
 			      ("orderBy" . "startTime")
 			      ("grant_type" . "authorization_code"))
@@ -179,7 +178,6 @@
 		    url
 		    :type "GET"
 		    :params `(("access_token" . ,(org-gtasks-access-token account))
-			      ("key" . ,(org-gtasks-client-secret account))
 			      ("singleEvents" . "True")
 			      ("orderBy" . "startTime")
 			      ("grant_type" . "authorization_code"))
@@ -258,7 +256,6 @@
    :headers '(("Content-Type" . "application/json"))
    :data (json-encode data-list)
    :params `(("access_token" . ,(org-gtasks-access-token account))
-	     ("key" . ,(org-gtasks-client-secret account))
 	     ("grant_type" . "authorization_code"))
    :parser 'org-gtasks-json-read
    :error (cl-function
@@ -274,7 +271,6 @@
    :type "DELETE"
    :headers '(("Content-Type" . "application/json"))
    :params `(("access_token" . ,(org-gtasks-access-token account))
-	     ("key" . ,(org-gtasks-client-secret account))
 	     ("grant_type" . "authorization_code"))
    :parser 'org-gtasks-json-read
    :error (cl-function
@@ -365,7 +361,6 @@
 		    :headers '(("Content-Type" . "application/json"))
 		    :data (json-encode `(("title" . ,name)))
 		    :params `(("access_token" . ,(org-gtasks-access-token account))
-			      ("key" . ,(org-gtasks-client-secret account))
 			      ("grant_type" . "authorization_code"))
 		    :parser 'org-gtasks-json-read
 		    :error (cl-function
@@ -389,7 +384,6 @@
    :type "DELETE"
    :headers '(("Content-Type" . "application/json"))
    :params `(("access_token" . ,(org-gtasks-access-token account))
-	     ("key" . ,(org-gtasks-client-secret account))
 	     ("grant_type" . "authorization_code"))
    :parser 'org-gtasks-json-read
    :error (cl-function


### PR DESCRIPTION
org-gtasks started to fail for me, with an error 400. Debugging the RPC led me to remove this key attribute. Now I can sync the tasks again.