### PR TITLE
Fix HTTP 400 when trying to pull task list

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,7 +27,7 @@ org files stored in a particular directory like so:
 3. Click on the project
 4. Click on *APIs & Services* then *Credentials*
 5. Click on *Create credentials* and select *OAuth Client ID*
-6. Select Application type /Other/ and give a name (e.g. /emacs/)
+6. Select Application type /Desktop/ and give a name (e.g. /emacs/)
 6. Click on *Create*
 7. Copy the /Client ID/ and /Client secret/ into the relevant fields in the config (see below)
 8. Under the same *APIs & Services* menu section, select *Library*

--- a/org-gtasks.el
+++ b/org-gtasks.el
@@ -1,9 +1,13 @@
-;;; org-gtasks.el -- Export/import all Google Tasks to org files.
-
-;; Copyright (C) 2018-2019 Julien Masson
+;;; org-gtasks.el --- Export/import all Google Tasks to org files.
 
 ;; Author: Julien Masson <massonju.eseo@gmail.com>
 ;; URL: https://github.com/JulienMasson/org-gtasks
+;; Version: 0.1
+;; Maintainer: massonju.eseo
+;; Copyright (C) :2018-2019 Julien Masson all rights reserved.
+;; Created: :30-08-18
+;; Package-Requires: ((emacs "24") (cl-lib "0.5") (org "8.2.4"))
+;; Keywords: convenience,
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/org-gtasks.el
+++ b/org-gtasks.el
@@ -26,16 +26,16 @@
 (require 'request)
 (require 'cl-lib)
 
-(defconst org-gtasks-token-url "https://www.googleapis.com/oauth2/v3/token"
+(defconst org-gtasks-token-url "https://oauth2.googleapis.com/token"
   "Google OAuth2 server URL.")
 
-(defconst org-gtasks-auth-url "https://accounts.google.com/o/oauth2/auth"
+(defconst org-gtasks-auth-url "https://accounts.google.com/o/oauth2/v2/auth"
   "Google OAuth2 server URL.")
 
 (defconst org-gtasks-resource-url "https://www.googleapis.com/auth/tasks"
   "URL used to request access to tasks resources.")
 
-(defconst org-gtasks-default-url "https://www.googleapis.com/tasks/v1")
+(defconst org-gtasks-default-url "https://tasks.googleapis.com/tasks/v1")
 
 (defvar org-gtasks-accounts nil)
 
@@ -69,6 +69,7 @@
                       "?client_id=" (url-hexify-string (org-gtasks-client-id account))
                       "&response_type=code"
                       "&redirect_uri=" (url-hexify-string "urn:ietf:wg:oauth:2.0:oob")
+                      "&access_type=offline"
                       "&scope=" (url-hexify-string org-gtasks-resource-url)))
   (read-string "Enter the code your browser displayed: "))
 
@@ -165,7 +166,6 @@
 		    url
 		    :type "GET"
 		    :params `(("access_token" . ,(org-gtasks-access-token account))
-			      ("key" . ,(org-gtasks-client-secret account))
 			      ("singleEvents" . "True")
 			      ("orderBy" . "startTime")
 			      ("grant_type" . "authorization_code"))
@@ -183,7 +183,6 @@
 		    url
 		    :type "GET"
 		    :params `(("access_token" . ,(org-gtasks-access-token account))
-			      ("key" . ,(org-gtasks-client-secret account))
 			      ("singleEvents" . "True")
 			      ("orderBy" . "startTime")
 			      ("grant_type" . "authorization_code"))
@@ -502,3 +501,8 @@
 
 
 (provide 'org-gtasks)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; tab-width: 8
+;; End:


### PR DESCRIPTION
Either something changed in the API or I setup my project wrong in the google developer console. The README mentions using application type "other" which doesn't seem to exist anymore so I used "Desktop" instead. 
I was getting "HTTP 400" when trying to pull the tasklist. It seems that the "key" parameter is invalid at this stage. These changes seem to fix it in my case.
Also I made some changes to the header so that the package can be installed using a quelpa recipe.

Thanks for your work on this !
